### PR TITLE
Allows user to set `withCredentials` flag to be used by superAgent on requests

### DIFF
--- a/lib/actions/mutation.js
+++ b/lib/actions/mutation.js
@@ -27,7 +27,7 @@ export default function (options, callback = false) {
     invariant(options.fragments, 'Relate: Mutation needs fragments defined');
 
     const mutation = buildQueryAndVariables(options.fragments, options.variables, 'mutation');
-    const {headers, endpoint, body} = getState().relateReducer;
+    const {headers, endpoint, body, withCredentials} = getState().relateReducer;
     return request({
       dispatch,
       type: actionTypes.mutation,
@@ -38,7 +38,8 @@ export default function (options, callback = false) {
       mutates: options.mutates,
       headers: options.headers || headers,
       body: options.body || body,
-      endpoint: options.endpoint || endpoint
+      endpoint: options.endpoint || endpoint,
+      withCredentials
     }).then((result) => {
       if (callback !== false) {
         callback(result, dispatch);

--- a/lib/actions/query.js
+++ b/lib/actions/query.js
@@ -37,7 +37,7 @@ export default function graphql (
           warning(false, err);
         });
     } else {
-      const {headers, endpoint, body} = getState().relateReducer;
+      const {headers, endpoint, body, withCredentials} = getState().relateReducer;
       result = request({
         dispatch,
         type: actionTypes.query,
@@ -48,7 +48,8 @@ export default function graphql (
         fragments,
         headers: config && config.headers || headers,
         body: config && config.body || body,
-        endpoint: config && config.endpoint || endpoint
+        endpoint: config && config.endpoint || endpoint,
+        withCredentials
       });
     }
 

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -17,6 +17,10 @@ export default function doRequest ({dispatch, query, variables, type, endpoint, 
         .set(headers)
         .send(payload);
 
+      if (params.withCredentials) {
+        req.withCredentials();
+      }
+
       req
         .end((error, res) => {
           if (error) {

--- a/lib/reducer/reducer.js
+++ b/lib/reducer/reducer.js
@@ -21,7 +21,8 @@ const defaultState = {
     Accept: 'application/json'
   },
   body: {},
-  endpoint: '/graphql'
+  endpoint: '/graphql',
+  withCredentials: false
 };
 
 export function relateReducer (_state = defaultState, action = {}) {

--- a/test/reducer/reducer.js
+++ b/test/reducer/reducer.js
@@ -19,16 +19,22 @@ describe('Reducer', () => {
         Accept: 'application/json'
       },
       body: {},
-      endpoint: '/test'
+      endpoint: '/test',
+      withCredentials: false
     });
-    const reducer1 = relateReducerInit({headers: {test: 1}});
+
+    const reducer1 = relateReducerInit({
+      headers: {test: 1},
+      withCredentials: true
+    });
     const newState1 = reducer1();
     expect(newState1).toEqual({
       headers: {
         test: 1
       },
       body: {},
-      endpoint: '/test'
+      endpoint: '/test',
+      withCredentials: true
     });
 
     // revert
@@ -37,7 +43,8 @@ describe('Reducer', () => {
         'Content-Type': 'application/json',
         Accept: 'application/json'
       },
-      endpoint: '/graphql'
+      endpoint: '/graphql',
+      withCredentials: false
     });
     const newState2 = reducer2();
     expect(newState2).toEqual({
@@ -46,7 +53,8 @@ describe('Reducer', () => {
         Accept: 'application/json'
       },
       body: {},
-      endpoint: '/graphql'
+      endpoint: '/graphql',
+      withCredentials: false
     });
   });
 

--- a/test/reducer/settings.js
+++ b/test/reducer/settings.js
@@ -11,7 +11,8 @@ describe('Settings', () => {
         Accept: 'application/json'
       },
       body: {},
-      endpoint: '/graphql'
+      endpoint: '/graphql',
+      withCredentials: false
     };
 
     expect(relateReducer()).toEqual(expectedState);


### PR DESCRIPTION
Example:
Set `withCredentials` flag on relateReducerInit

```
relateReducerInit({
  withCredentials: true
})
```

```
req.post(ENDPOINT).withCredentials()...
```