### PR TITLE
Fix bug that was causing relate to break when relativeNodes is `null`

### DIFF
--- a/lib/store/connectors.js
+++ b/lib/store/connectors.js
@@ -163,18 +163,20 @@ export default class Connectors {
               );
             }
           } else if (action.type === 'APPEND' || action.type === 'PREPEND') {
-            let nodesToAdd;
+            let nodesToAdd = [];
 
-            if (action.select) {
-              nodesToAdd =
-                relativeNodes[action.select].constructor === Array ?
-                relativeNodes[action.select] :
-                [relativeNodes[action.select]];
-            } else {
-              nodesToAdd =
-                relativeNodes.constructor === Array ?
-                relativeNodes :
-                [relativeNodes];
+            if (relativeNodes) {
+              if (action.select) {
+                nodesToAdd =
+                  relativeNodes[action.select].constructor === Array ?
+                  relativeNodes[action.select] :
+                  [relativeNodes[action.select]];
+              } else {
+                nodesToAdd =
+                  relativeNodes.constructor === Array ?
+                  relativeNodes :
+                  [relativeNodes];
+              }
             }
 
             if (action.accept) {


### PR DESCRIPTION
When the mutation response has no data, `relativeNodes` is `null` at this point causing `relate` action to fail.
